### PR TITLE
Removed call to reset method

### DIFF
--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -708,7 +708,7 @@ void on_sta_upload_fin() {
 
   if(!verify_device_key()) {
     server_send_result(HTML_UNAUTHORIZED);
-    Update.reset();
+    Update.end(false); // Update.reset(); FAB
     return;
   }
 


### PR DESCRIPTION
Removed call to exposed reset method in Updater.h from ESP8266 library. I installed ESP8266 library without modifying it.

Tested by entering incorrect device key, and attempted to upload. Received incorrect device key error.
Proceeded to re-attempt upload, by entering correct device key, and upload went through with no issues.

In reference to [Issue#29](https://github.com/OpenGarage/OpenGarage-Firmware/issues/29)