### PR TITLE
Add capability for MQTT to transmit distance

### DIFF
--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -1213,11 +1213,13 @@ void check_status() {
         if(door_status == DOOR_STATUS_REMAIN_OPEN)  {						// MQTT: If door open...
           mqttclient.publish(og.options[OPTION_NAME].sval + "/OUT/STATE","OPEN");
           mqttclient.publish(og.options[OPTION_NAME].sval,"Open"); //Support existing mqtt code
+          mqttclient.publish(og.options[OPTION_NAME].sval + "/OUT/DIST", String(distance));
           //DEBUG_PRINTLN(curr_utc_time + " Sending MQTT State otification: OPEN");
         } 
         else if(door_status == DOOR_STATUS_REMAIN_CLOSED) {					// MQTT: If door closed...
           mqttclient.publish(og.options[OPTION_NAME].sval + "/OUT/STATE","CLOSED");
           mqttclient.publish(og.options[OPTION_NAME].sval,"Closed"); //Support existing mqtt code
+          mqttclient.publish(og.options[OPTION_NAME].sval + "/OUT/DIST", String(distance));
           //DEBUG_PRINTLN(curr_utc_time + " Sending MQTT State Notification: CLOSED");
         }
       }


### PR DESCRIPTION
This update will transmit distance readings over the "<Device Name>/OUT/DIST" MQTT topic. I am using this to filter out any anomalous distance readings I get. This is only sending door distance at the moment, but it would be trivial to add vehicle distance as well. This is more just a proof of concept/starting point before I move forward with anything more.

Important Notes: I did have some trouble initially after flashing the updated firmware to my device. I think it was because the device was trying to make a connection to the MQTT broker, but the old appeared to exist already. So, the device couldn't connect and couldn't serve its HTTP interface (related issue https://github.com/OpenGarage/OpenGarage-Firmware/issues/36). So I'd definitely want some more testing on this before merging. If nothing else, a recommendation to remote the MQTT configuration on the device temporarily, restart, flash the firmware, and then re-enable MQTT might be enough to mitigate the issue. (I'm honestly not exactly sure how I got it working again, I tried multiple times to factory reset and also unplugged and plugged it back in once before it suddenly started working again. So, the code itself should be good but I think there's some things around the update process to work through with MQTT.)