### PR TITLE
Add configurable MQTT port, username, and password support.

### DIFF
--- a/OpenGarage/OpenGarage.cpp
+++ b/OpenGarage/OpenGarage.cpp
@@ -70,6 +70,9 @@ OptionStruct OpenGarage::options[] = {
   {"name", 0, 0, DEFAULT_NAME},
   {"iftt", 0, 0, ""},
   {"mqtt", 0, 0, "-.-.-.-"},
+  {"mqpt", 1883,65535, ""},
+  {"mqun", 0, 0, ""},
+  {"mqpw", 0, 0, ""},
   {"dvip", 0, 0, "-.-.-.-"},
   {"gwip", 0, 0, "-.-.-.-"},
   {"subn", 0, 0, "255.255.255.0"}

--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -141,6 +141,9 @@ typedef enum {
   OPTION_NAME,    // device name
   OPTION_IFTT,    // IFTTT token
   OPTION_MQTT,    // MQTT IP
+  OPTION_MQPT,    // MQTT Port
+  OPTION_MQUN,    // MQTT Username
+  OPTION_MQPW,    // MQTT Password
   OPTION_DVIP,    // device IP
   OPTION_GWIP,    // gateway IP
   OPTION_SUBN,    // subnet

--- a/OpenGarage/html/sta_options.html
+++ b/OpenGarage/html/sta_options.html
@@ -61,6 +61,9 @@
 <tr><td><b>Blynk Port:</b></td><td><input type='text' size=5 maxlength=5 id='bprt' data-mini='true' value=0></td></tr>
 <tr><td><b>IFTTT Key:</b></td><td><input type='text' size=20 maxlength=64 id='iftt' data-mini='true' value='-'></td></tr>
 <tr><td><b>MQTT Server:</b></td><td><input type='text' size=16 maxlength=20 id='mqtt' data-mini='true' value=''></td></tr>
+<tr><td><b>MQTT Port:</b></td><td><input type='text' size=5 maxlength=5 id='mqpt' data-mini='true' value=0></td></tr>
+<tr><td><b>MQTT Username:</b></td><td><input type='text' size=16 maxlength=23 id='mqun' data-mini='true' value=''></td></tr>
+<tr><td><b>MQTT Password:</b></td><td><input type='password' size=16 maxlength=64 id='mqpw' data-mini='true' value=''></td></tr>
 </table>
 <table>
   <tr><td colspan=4><b>Choose Notifications:</b></td></tr>
@@ -165,6 +168,9 @@ comm+='&bdmn='+encodeURIComponent($('#bdmn').val());
 comm+='&bprt='+$('#bprt').val();
 comm+='&iftt='+encodeURIComponent($('#iftt').val());
 comm+='&mqtt='+encodeURIComponent($('#mqtt').val());
+comm+='&mqpt='+encodeURIComponent($('#mqpt').val());
+comm+='&mqun='+encodeURIComponent($('#mqun').val());
+comm+='&mqpw='+encodeURIComponent($('#mqpw').val());
 if($('#cb_key').is(':checked')) {
 if(!$('#nkey').val()) {
 if(!confirm('New device key is empty. Are you sure?')) return;
@@ -216,6 +222,9 @@ $('#bdmn').val(jd.bdmn);
 $('#bprt').val(jd.bprt);
 $('#iftt').val(jd.iftt);
 $('#mqtt').val(jd.mqtt);
+$('#mqpt').val(jd.mqpt);
+$('#mqun').val(jd.mqun);
+$('#mqpw').val(jd.mqpw);
 $('#dvip').val(jd.dvip);
 $('#gwip').val(jd.gwip);
 $('#subn').val(jd.subn);

--- a/OpenGarage/htmls.h
+++ b/OpenGarage/htmls.h
@@ -365,6 +365,9 @@ const char sta_options_html[] PROGMEM = R"(<head><title>OpenGarage</title><meta 
 <tr><td><b>Blynk Port:</b></td><td><input type='text' size=5 maxlength=5 id='bprt' data-mini='true' value=0></td></tr>
 <tr><td><b>IFTTT Key:</b></td><td><input type='text' size=20 maxlength=64 id='iftt' data-mini='true' value='-'></td></tr>
 <tr><td><b>MQTT Server:</b></td><td><input type='text' size=16 maxlength=20 id='mqtt' data-mini='true' value=''></td></tr>
+<tr><td><b>MQTT Port:</b></td><td><input type='text' size=5 maxlength=5 id='mqpt' data-mini='true' value=0></td></tr>
+<tr><td><b>MQTT Username:</b></td><td><input type='text' size=16 maxlength=23 id='mqun' data-mini='true' value=''></td></tr>
+<tr><td><b>MQTT Password:</b></td><td><input type='password' size=16 maxlength=64 id='mqpw' data-mini='true' value=''></td></tr>
 </table>
 <table>
 <tr><td colspan=4><b>Choose Notifications:</b></td></tr>
@@ -469,6 +472,9 @@ comm+='&bdmn='+encodeURIComponent($('#bdmn').val());
 comm+='&bprt='+$('#bprt').val();
 comm+='&iftt='+encodeURIComponent($('#iftt').val());
 comm+='&mqtt='+encodeURIComponent($('#mqtt').val());
+comm+='&mqpt='+encodeURIComponent($('#mqpt').val());
+comm+='&mqun='+encodeURIComponent($('#mqun').val());
+comm+='&mqpw='+encodeURIComponent($('#mqpw').val());
 if($('#cb_key').is(':checked')) {
 if(!$('#nkey').val()) {
 if(!confirm('New device key is empty. Are you sure?')) return;
@@ -520,6 +526,9 @@ $('#bdmn').val(jd.bdmn);
 $('#bprt').val(jd.bprt);
 $('#iftt').val(jd.iftt);
 $('#mqtt').val(jd.mqtt);
+$('#mqpt').val(jd.mqpt);
+$('#mqun').val(jd.mqun);
+$('#mqpw').val(jd.mqpw);
 $('#dvip').val(jd.dvip);
 $('#gwip').val(jd.gwip);
 $('#subn').val(jd.subn);

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -940,17 +940,26 @@ bool mqtt_connect_subscibe() {
         connected = mqttclient.connect(
           og.options[OPTION_NAME].sval.c_str(),
           og.options[OPTION_MQUN].sval.c_str(),
-          og.options[OPTION_MQPW].sval.c_str()
+          og.options[OPTION_MQPW].sval.c_str(),
+          (og.options[OPTION_NAME].sval + "/OUT/STATUS").c_str(),
+          1,
+          true,
+          "offline"
         );
       } else {
         connected = mqttclient.connect(
-          og.options[OPTION_NAME].sval.c_str()
+          og.options[OPTION_NAME].sval.c_str(),
+          (og.options[OPTION_NAME].sval + "/OUT/STATUS").c_str(),
+          1,
+          true,
+          "offline"
         );
       }
       if (connected) {
         mqttclient.setCallback(mqtt_callback);
         mqttclient.subscribe(og.options[OPTION_NAME].sval.c_str());
         mqttclient.subscribe((og.options[OPTION_NAME].sval +"/IN/#").c_str());
+        mqttclient.publish((og.options[OPTION_NAME].sval + "/OUT/STATUS").c_str(), "online", true);
         DEBUG_PRINTLN(F("......Success, Subscribed to MQTT Topic"));
         return true;
       }else {

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -696,8 +696,10 @@ void on_ap_debug() {
 }
 
 // MQTT callback to read "Button" requests
-void mqtt_callback(char *topic, byte *bytePayload, unsigned int length) {
+void mqtt_callback(char *charTopic, byte *bytePayload, unsigned int length) {
+  bytePayload[length] = NULL;
   String payload((char*)bytePayload);
+  String topic(charTopic);
 
   //DEBUG_PRINT("MQTT Message Received: ");
   //DEBUG_PRINT(payload);
@@ -705,7 +707,7 @@ void mqtt_callback(char *topic, byte *bytePayload, unsigned int length) {
   //DEBUG_PRINTLN(topic);
 
   //Accept button on any topic for backwards compat with existing code - use IN messages below if possible
-  if (topic == "Button") {
+  if (payload == "Button") {
     DEBUG_PRINTLN(F("MQTT Button request received, change door state"));
     if(!og.options[OPTION_ALM].ival) {
       // if alarm is not enabled, trigger relay right away
@@ -717,10 +719,10 @@ void mqtt_callback(char *topic, byte *bytePayload, unsigned int length) {
     }
   }
   //Accept click for consistency with api, open and close should be used instead, use IN topic if possible
-  if (payload == og.options[OPTION_NAME].sval + "/IN/STATE"){
+  if (topic == og.options[OPTION_NAME].sval + "/IN/STATE"){
     DEBUG_PRINT(F("MQTT IN Message detected, check data for action, Data:"));
-    DEBUG_PRINTLN(topic);
-    if ((topic == "close" && door_status) || (topic == "open" && !door_status) || topic == "click") {
+    DEBUG_PRINTLN(payload);
+    if ((payload == "close" && door_status) || (payload == "open" && !door_status) || payload == "click") {
       DEBUG_PRINTLN(F("Command is valid based on existing state, trigger change"));
       if(!og.options[OPTION_ALM].ival) {
         // if alarm is not enabled, trigger relay right away
@@ -730,12 +732,12 @@ void mqtt_callback(char *topic, byte *bytePayload, unsigned int length) {
         // else, set alarm
         og.set_alarm();
       }
-    } else if ((topic == "close" && !door_status) || (topic == "open" && door_status)) {
+    } else if ((payload == "close" && !door_status) || (payload == "open" && door_status)) {
       DEBUG_PRINTLN(F("Command request not valid, door already in requested state"));
     }
     else {
       DEBUG_PRINT(F("Unrecognized MQTT data/command:"));
-      DEBUG_PRINTLN(topic);
+      DEBUG_PRINTLN(payload);
     }
   }
 }

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -1228,13 +1228,13 @@ void check_status() {
       if((og.options[OPTION_MQTT].sval.length()>8) && (mqttclient.connected())) {
         DEBUG_PRINTLN(F(" Update MQTT (State Refresh)"));
         if(door_status == DOOR_STATUS_REMAIN_OPEN)  {						// MQTT: If door open...
-          mqttclient.publish((og.options[OPTION_NAME].sval + "/OUT/STATE").c_str(), "OPEN");
-          mqttclient.publish(og.options[OPTION_NAME].sval.c_str(), "Open"); //Support existing mqtt code
+          mqttclient.publish((og.options[OPTION_NAME].sval + "/OUT/STATE").c_str(), "OPEN", true);
+          mqttclient.publish(og.options[OPTION_NAME].sval.c_str(), "Open", true); //Support existing mqtt code
           //DEBUG_PRINTLN(curr_utc_time + " Sending MQTT State otification: OPEN");
         } 
         else if(door_status == DOOR_STATUS_REMAIN_CLOSED) {					// MQTT: If door closed...
-          mqttclient.publish((og.options[OPTION_NAME].sval + "/OUT/STATE").c_str(), "CLOSED");
-          mqttclient.publish(og.options[OPTION_NAME].sval.c_str(), "Closed"); //Support existing mqtt code
+          mqttclient.publish((og.options[OPTION_NAME].sval + "/OUT/STATE").c_str(), "CLOSED", true);
+          mqttclient.publish(og.options[OPTION_NAME].sval.c_str(), "Closed", true); //Support existing mqtt code
           //DEBUG_PRINTLN(curr_utc_time + " Sending MQTT State Notification: CLOSED");
         }
       }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For Firmware release notes, go to [https://github.com/OpenGarage/OpenGarage-Firm
 * Arduino (https://arduino.cc) with ESP8266 core 2.4.1 or above for Arduino (https://github.com/esp8266/Arduino/releases/tag/2.4.1)
 * Instead of installing Arduino, you can also directly use make (this folder includes a copy of **makeESPArduino**: https://github.com/plerup/makeEspArduino)
 * Blynk library for Arduino (https://github.com/blynkkk/blynk-library)
-* MQTT PubSUbClient https://github.com/Imroy/pubsubclient/releases
+* MQTT PubSubClient https://github.com/knolleary/pubsubclient/releases
 * AM2320 library: https://github.com/hibikiledo/AM2320/releases
 * OneWire library: https://www.pjrc.com/teensy/td_libs_OneWire.html
 * DallasTemperature library: https://github.com/milesburton/Arduino-Temperature-Control-Library/releases


### PR DESCRIPTION
This commit adds web configuration and backend functionality to specify MQTT port, username, and password. I have tested it successfully locally with up to a 64-character password and everything was working great! If a username and password are not entered, MQTT operates as an anonymous user similar to current functionality.

Note that the PubSubClient dependency switches to [knolleary/pubsubclient](https://github.com/knolleary/pubsubclient) with this request since it correctly works with auth, while the current library caused protocol errors.