### PR TITLE
Add custom NTP server option

### DIFF
--- a/OpenGarage/OpenGarage.cpp
+++ b/OpenGarage/OpenGarage.cpp
@@ -51,6 +51,7 @@ OptionStruct OpenGarage::options[] = {
   {"lsz", DEFAULT_LOG_SIZE,400,""},
   {"tsn", OG_TSN_NONE, 255, ""},
   {"htp", 80,        65535, ""},
+  {"ntpe", 0,            1, ""},
   {"ntp", 0,      0, "-.-.-.-"},
   {"cdt", 1000,       5000, ""},
   {"dri", 500,        3000, ""},

--- a/OpenGarage/OpenGarage.cpp
+++ b/OpenGarage/OpenGarage.cpp
@@ -51,6 +51,7 @@ OptionStruct OpenGarage::options[] = {
   {"lsz", DEFAULT_LOG_SIZE,400,""},
   {"tsn", OG_TSN_NONE, 255, ""},
   {"htp", 80,        65535, ""},
+  {"ntp", 0,      0, "-.-.-.-"},
   {"cdt", 1000,       5000, ""},
   {"dri", 500,        3000, ""},
   {"sto", 0,             1, ""},

--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -122,6 +122,7 @@ typedef enum {
   OPTION_LSZ,     // log size
   OPTION_TSN,     // temperature sensor type
   OPTION_HTP,     // http port
+  OPTION_NTP,     // NTP Server
   OPTION_CDT,     // click delay time
   OPTION_DRI,			// distance read interval
   OPTION_STO,			// sensor timeout option

--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -122,6 +122,7 @@ typedef enum {
   OPTION_LSZ,     // log size
   OPTION_TSN,     // temperature sensor type
   OPTION_HTP,     // http port
+  OPTION_NTPE,    // Custom NTP server enabled
   OPTION_NTP,     // NTP Server
   OPTION_CDT,     // click delay time
   OPTION_DRI,			// distance read interval

--- a/OpenGarage/html/sta_options.html
+++ b/OpenGarage/html/sta_options.html
@@ -77,7 +77,8 @@
 <div id='div_other' style='display:none;'>
 <table cellpadding=2>
 <tr><td><b>HTTP Port:</b></td><td><input type='text' size=5 maxlength=5 id='htp' value=0 data-mini='true'></td></tr>
-<tr><td><b>NTP Server:</b></td><td><input type='text' size=16 maxlength=20 id='ntp' value='' data-mini='true'></td></tr>
+<tr><td colspan=2><input type='checkbox' id='ntpe' data-mini='true'><label for='ntpe'>Use Custom NTP Server</label></td></tr>
+<tr><td><b>NTP Server:</b></td><td><input type='text' size=16 maxlength=20 id='ntp' data-mini='true'></td></tr>
 <tr><td colspan=2><input type='checkbox' id='usi' data-mini='true'><label for='usi'>Use Static IP</label></td></tr>
 <tr><td><b>Device IP:</b></td><td><input type='text' size=15 maxlength=15 id='dvip' data-mini='true' disabled></td></tr>
 <tr><td><b>Gateway IP:</b></td><td><input type='text' size=15 maxlength=15 id='gwip' data-mini='true' disabled></td></tr>
@@ -118,6 +119,9 @@ $('#cb_key').click(function(e){
 $('#nkey').textinput($(this).is(':checked')?'enable':'disable');
 $('#ckey').textinput($(this).is(':checked')?'enable':'disable');
 });
+$('#ntpe').click(function(e){
+$('#ntp').textinput($(this).is(':checked')?'enable':'disable');
+});
 $('#usi').click(function(e){
 $('#dvip').textinput($(this).is(':checked')?'enable':'disable');
 $('#gwip').textinput($(this).is(':checked')?'enable':'disable');
@@ -146,7 +150,6 @@ comm+='&alm='+$('#alm').val();
 comm+='&lsz='+$('#lsz').val();
 comm+='&tsn='+$('#tsn').val();
 comm+='&htp='+$('#htp').val();
-comm+='&ntp='+$('#ntp').val()
 comm+='&cdt='+$('#cdt').val();
 comm+='&dri='+$('#dri').val();
 comm+='&sto='+eval_cb('#to_cap');
@@ -173,6 +176,11 @@ if(!confirm('New device key is empty. Are you sure?')) return;
 }
 comm+='&nkey='+encodeURIComponent($('#nkey').val());
 comm+='&ckey='+encodeURIComponent($('#ckey').val());
+}
+if($('#ntpe').is(':checked')) {
+comm+='&ntpe=1&ntp='+($('#ntp').val());
+} else {
+comm+='&ntpe=0';
 }
 if($('#usi').is(':checked')) {
 comm+='&usi=1&dvip='+($('#dvip').val())+'&gwip='+($('#gwip').val());
@@ -203,7 +211,6 @@ $('#dth').val(jd.dth);
 $('#vth').val(jd.vth);
 $('#riv').val(jd.riv);
 $('#htp').val(jd.htp);
-$('#ntp').val(jd.ntp);
 $('#cdt').val(jd.cdt);
 $('#dri').val(jd.dri);
 if(jd.sto) $('#to_cap').attr('checked',true).checkboxradio('refresh');
@@ -219,9 +226,12 @@ $('#bdmn').val(jd.bdmn);
 $('#bprt').val(jd.bprt);
 $('#iftt').val(jd.iftt);
 $('#mqtt').val(jd.mqtt);
+$('#ntp').val(jd.ntp);
 $('#dvip').val(jd.dvip);
 $('#gwip').val(jd.gwip);
 $('#subn').val(jd.subn);
+if(jd.ntpe>0) $('#ntpe').attr('checked',true).checkboxradio('refresh');
+$('#ntp').textinput(jd.ntpe>0?'enable':'disable');
 if(jd.usi>0) $('#usi').attr('checked',true).checkboxradio('refresh');
 $('#dvip').textinput(jd.usi>0?'enable':'disable');
 $('#gwip').textinput(jd.usi>0?'enable':'disable');

--- a/OpenGarage/html/sta_options.html
+++ b/OpenGarage/html/sta_options.html
@@ -77,6 +77,7 @@
 <div id='div_other' style='display:none;'>
 <table cellpadding=2>
 <tr><td><b>HTTP Port:</b></td><td><input type='text' size=5 maxlength=5 id='htp' value=0 data-mini='true'></td></tr>
+<tr><td><b>NTP Server:</b></td><td><input type='text' size=16 maxlength=20 id='ntp' value='' data-mini='true'></td></tr>
 <tr><td colspan=2><input type='checkbox' id='usi' data-mini='true'><label for='usi'>Use Static IP</label></td></tr>
 <tr><td><b>Device IP:</b></td><td><input type='text' size=15 maxlength=15 id='dvip' data-mini='true' disabled></td></tr>
 <tr><td><b>Gateway IP:</b></td><td><input type='text' size=15 maxlength=15 id='gwip' data-mini='true' disabled></td></tr>
@@ -145,6 +146,7 @@ comm+='&alm='+$('#alm').val();
 comm+='&lsz='+$('#lsz').val();
 comm+='&tsn='+$('#tsn').val();
 comm+='&htp='+$('#htp').val();
+comm+='&ntp='+$('#ntp').val()
 comm+='&cdt='+$('#cdt').val();
 comm+='&dri='+$('#dri').val();
 comm+='&sto='+eval_cb('#to_cap');
@@ -201,6 +203,7 @@ $('#dth').val(jd.dth);
 $('#vth').val(jd.vth);
 $('#riv').val(jd.riv);
 $('#htp').val(jd.htp);
+$('#ntp').val(jd.ntp);
 $('#cdt').val(jd.cdt);
 $('#dri').val(jd.dri);
 if(jd.sto) $('#to_cap').attr('checked',true).checkboxradio('refresh');

--- a/OpenGarage/htmls.h
+++ b/OpenGarage/htmls.h
@@ -381,6 +381,7 @@ const char sta_options_html[] PROGMEM = R"(<head><title>OpenGarage</title><meta 
 <div id='div_other' style='display:none;'>
 <table cellpadding=2>
 <tr><td><b>HTTP Port:</b></td><td><input type='text' size=5 maxlength=5 id='htp' value=0 data-mini='true'></td></tr>
+<tr><td colspan=2><input type='checkbox' id='ntpe' data-mini='true'><label for='ntpe'>Use Custom NTP Server</label></td></tr>
 <tr><td><b>NTP Server:</b></td><td><input type='text' size=16 maxlength=20 id='ntp' value='' data-mini='true'></td></tr>
 <tr><td colspan=2><input type='checkbox' id='usi' data-mini='true'><label for='usi'>Use Static IP</label></td></tr>
 <tr><td><b>Device IP:</b></td><td><input type='text' size=15 maxlength=15 id='dvip' data-mini='true' disabled></td></tr>
@@ -422,6 +423,9 @@ $('#cb_key').click(function(e){
 $('#nkey').textinput($(this).is(':checked')?'enable':'disable');
 $('#ckey').textinput($(this).is(':checked')?'enable':'disable');
 });
+$('#ntpe').click(function(e){
+$('#ntp').textinput($(this).is(':checked')?'enable':'disable');
+});
 $('#usi').click(function(e){
 $('#dvip').textinput($(this).is(':checked')?'enable':'disable');
 $('#gwip').textinput($(this).is(':checked')?'enable':'disable');
@@ -450,7 +454,6 @@ comm+='&alm='+$('#alm').val();
 comm+='&lsz='+$('#lsz').val();
 comm+='&tsn='+$('#tsn').val();
 comm+='&htp='+$('#htp').val();
-comm+='&ntp='+$('#ntp').val();
 comm+='&cdt='+$('#cdt').val();
 comm+='&dri='+$('#dri').val();
 comm+='&sto='+eval_cb('#to_cap');
@@ -477,6 +480,11 @@ if(!confirm('New device key is empty. Are you sure?')) return;
 }
 comm+='&nkey='+encodeURIComponent($('#nkey').val());
 comm+='&ckey='+encodeURIComponent($('#ckey').val());
+}
+if($('#ntpe').is(':checked')) {
+comm+='&ntpe=1&ntp='+($('#ntp').val());
+} else {
+comm+='&ntpe=0';
 }
 if($('#usi').is(':checked')) {
 comm+='&usi=1&dvip='+($('#dvip').val())+'&gwip='+($('#gwip').val());
@@ -507,7 +515,6 @@ $('#dth').val(jd.dth);
 $('#vth').val(jd.vth);
 $('#riv').val(jd.riv);
 $('#htp').val(jd.htp);
-$('#ntp').val(jd.ntp);
 $('#cdt').val(jd.cdt);
 $('#dri').val(jd.dri);
 if(jd.sto) $('#to_cap').attr('checked',true).checkboxradio('refresh');
@@ -523,9 +530,12 @@ $('#bdmn').val(jd.bdmn);
 $('#bprt').val(jd.bprt);
 $('#iftt').val(jd.iftt);
 $('#mqtt').val(jd.mqtt);
+$('#ntp').val(jd.ntp);
 $('#dvip').val(jd.dvip);
 $('#gwip').val(jd.gwip);
 $('#subn').val(jd.subn);
+if(jd.ntpe>0) $('#ntpe').attr('checked',true).checkboxradio('refresh');
+$('#ntp').textinput(jd.ntpe>0?'enable':'disable');
 if(jd.usi>0) $('#usi').attr('checked',true).checkboxradio('refresh');
 $('#dvip').textinput(jd.usi>0?'enable':'disable');
 $('#gwip').textinput(jd.usi>0?'enable':'disable');

--- a/OpenGarage/htmls.h
+++ b/OpenGarage/htmls.h
@@ -381,6 +381,7 @@ const char sta_options_html[] PROGMEM = R"(<head><title>OpenGarage</title><meta 
 <div id='div_other' style='display:none;'>
 <table cellpadding=2>
 <tr><td><b>HTTP Port:</b></td><td><input type='text' size=5 maxlength=5 id='htp' value=0 data-mini='true'></td></tr>
+<tr><td><b>NTP Server:</b></td><td><input type='text' size=16 maxlength=20 id='ntp' value='' data-mini='true'></td></tr>
 <tr><td colspan=2><input type='checkbox' id='usi' data-mini='true'><label for='usi'>Use Static IP</label></td></tr>
 <tr><td><b>Device IP:</b></td><td><input type='text' size=15 maxlength=15 id='dvip' data-mini='true' disabled></td></tr>
 <tr><td><b>Gateway IP:</b></td><td><input type='text' size=15 maxlength=15 id='gwip' data-mini='true' disabled></td></tr>
@@ -449,6 +450,7 @@ comm+='&alm='+$('#alm').val();
 comm+='&lsz='+$('#lsz').val();
 comm+='&tsn='+$('#tsn').val();
 comm+='&htp='+$('#htp').val();
+comm+='&ntp='+$('#ntp').val();
 comm+='&cdt='+$('#cdt').val();
 comm+='&dri='+$('#dri').val();
 comm+='&sto='+eval_cb('#to_cap');
@@ -505,6 +507,7 @@ $('#dth').val(jd.dth);
 $('#vth').val(jd.vth);
 $('#riv').val(jd.riv);
 $('#htp').val(jd.htp);
+$('#ntp').val(jd.ntp);
 $('#cdt').val(jd.cdt);
 $('#dri').val(jd.dri);
 if(jd.sto) $('#to_cap').attr('checked',true).checkboxradio('refresh');

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -1271,8 +1271,13 @@ void time_keeping() {
   static ulong time_keeping_timeout = 0;
 
   if(!configured) {
-    DEBUG_PRINTLN(F("Set time server"));
-    configTime(0, 0, "time.google.com", "pool.ntp.org", NULL);
+    if (og.options[OPTION_NTP].sval.length() > 0) {
+      DEBUG_PRINTLN(F("Set custom time server"));
+      configTime(0, 0, og.options[OPTION_NTP].sval.c_str(), "time.google.com", "pool.ntp.org");
+    } else {
+      DEBUG_PRINTLN(F("Set default time server"));
+      configTime(0, 0, "time.google.com", "pool.ntp.org", NULL);
+    }
     configured = true;
   }
 

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -1271,7 +1271,7 @@ void time_keeping() {
   static ulong time_keeping_timeout = 0;
 
   if(!configured) {
-    if (og.options[OPTION_NTP].sval.length() > 0) {
+    if (og.options[OPTION_NTPE].ival > 0) {
       DEBUG_PRINTLN(F("Set custom time server"));
       configTime(0, 0, og.options[OPTION_NTP].sval.c_str(), "time.google.com", "pool.ntp.org");
     } else {


### PR DESCRIPTION
This commit add web configuration and backend NTP changes to specify a custom NTP server.

The default servers of time.google.com and pool.ntp.org will still be tried as a fallback, but the NTP that a user defines will be tried first.

Closes #38