### PR TITLE
Update device key max length on /update page

### DIFF
--- a/OpenGarage/html/sta_update.html
+++ b/OpenGarage/html/sta_update.html
@@ -12,7 +12,7 @@
     <form method='POST' action='/update' id='fm' enctype='multipart/form-data'>
     <table cellspacing=4>
     <tr><td><input type='file' name='file' accept='.bin' id='file'></td></tr>
-    <tr><td><b>Device key: </b><input type='password' name='dkey' size=16 maxlength=16 id='dkey'></td></tr>
+    <tr><td><b>Device key: </b><input type='password' name='dkey' size=16 maxlength=32 id='dkey'></td></tr>
     <tr><td><label id='msg'></label></td></tr>
     </table>
 		<div data-role='controlgroup' data-type='horizontal'>    


### PR DESCRIPTION
The max length for the device key is 32 characters on the `/vo` page where users can set the device key. The input field on the `/update` page should be updated to match, otherwise firmware updates fail when the device key is >16 characters.