### PR TITLE
defines.h: Fixing typo and adding nodemcu pin id comment

### DIFF
--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -33,9 +33,9 @@
 #define PIN_ECHO   14 // D5 on nodemcu
 #define PIN_LED     2
 #define PIN_RESET  16
-#define PIN_BUZZER 13
+#define PIN_BUZZER 13 // D7 on nodemcu
 #define PIN_SWITCH  4 // switch sensor: D2 on nodemcu
-#define PIN_TH      5 // temeprature sensor: D1 on nodemcu
+#define PIN_TH      5 // temperature sensor: D1 on nodemcu
 
 // Default device name
 #define DEFAULT_NAME    "My OpenGarage"


### PR DESCRIPTION
Fixing typo in word "temperature", also set the nodemcu pin id to match the rest of the comments