### PR TITLE
No internet causes api hangs

### DIFF
--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -196,15 +196,15 @@ typedef enum {
 #define LED_FAST_BLINK  100
 #define LED_SLOW_BLINK  500
 
-#define OG_NTP_CONFIGURE		0            // ntp config state
-#define OG_NTP_UPDATE_TIME		1            // ntp refresh state, initializes timeout handling
-#define OG_NTP_CALL_NTP			2            // actual ntp call, including success and basic retry states
-#define TIME_SYNC_CONFIG_DELAY	0            // delay between configuring the NTP class and actually using it, may not be needed anymore, so default to zero
-#define TIME_SYNC_RETRY_DELAY	2000         // delay between failed NTP calls, hopefully due to transient/startup issues
-#define TIME_SYNC_TIMEOUT		30000        // time limit before we give up calling NTP for a while, likely due to major issues, like a network outages
-#define TIME_SYNC_TIMEOUT_DELAY	60000        // delay before trying to call NTP again after a major issue
-#define TIME_SYNC_REFRESH 		1800000      // Issues connecting to MQTT can throw off the time function, sync more often
-#define TIME_SYNC_ERROR_DATE	1577836800UL // 2020-01-01T00:00:00Z - Arbitrary, but reasonable date to confirm NTP is working
+#define OG_NTP_CONFIGURE        0            // ntp config state
+#define OG_NTP_UPDATE_TIME      1            // ntp refresh state, initializes timeout handling
+#define OG_NTP_CALL_NTP         2            // actual ntp call, including success and basic retry states
+#define TIME_SYNC_CONFIG_DELAY  0            // delay between configuring the NTP class and actually using it, may not be needed anymore, so default to zero
+#define TIME_SYNC_RETRY_DELAY   2000         // delay between failed NTP calls, hopefully due to transient/startup issues
+#define TIME_SYNC_TIMEOUT       30000        // time limit before we give up calling NTP for a while, likely due to major issues, like a network outages
+#define TIME_SYNC_TIMEOUT_DELAY 60000        // delay before trying to call NTP again after a major issue
+#define TIME_SYNC_REFRESH       1800000      // Issues connecting to MQTT can throw off the time function, sync more often
+#define TIME_SYNC_ERROR_DATE    1577836800UL // 2020-01-01T00:00:00Z - Arbitrary, but reasonable date to confirm NTP is working
 
 #define TMP_BUFFER_SIZE 100
 

--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -196,7 +196,15 @@ typedef enum {
 #define LED_FAST_BLINK  100
 #define LED_SLOW_BLINK  500
 
-#define TIME_SYNC_TIMEOUT 1800 //Issues connecting to MQTT can throw off the time function, sync more often
+#define OG_NTP_CONFIGURE		0				// ntp config state
+#define OG_NTP_UPDATE_TIME		1				// ntp refresh state, initializes timeout handling
+#define OG_NTP_CALL_NTP			2				// actual ntp call, including success and basic retry states
+#define TIME_SYNC_CONFIG_DELAY	0				// delay between configuring the NTP class and actually using it, may not be needed anymore, so default to zero
+#define TIME_SYNC_RETRY_DELAY	2000			// delay between failed NTP calls, hopefully due to transient/startup issues
+#define TIME_SYNC_TIMEOUT		30000			// time limit before we give up calling NTP for a while, likely due to major issues, like a network outages
+#define TIME_SYNC_TIMEOUT_DELAY	60000			// delay before trying to call NTP again after a major issue
+#define TIME_SYNC_REFRESH 		1800000			// Issues connecting to MQTT can throw off the time function, sync more often
+#define TIME_SYNC_ERROR_DATE	1577836800UL	// 2020-01-01T00:00:00Z - Arbitrary, but reasonable date to confirm NTP is working
 
 #define TMP_BUFFER_SIZE 100
 

--- a/OpenGarage/defines.h
+++ b/OpenGarage/defines.h
@@ -196,15 +196,15 @@ typedef enum {
 #define LED_FAST_BLINK  100
 #define LED_SLOW_BLINK  500
 
-#define OG_NTP_CONFIGURE		0				// ntp config state
-#define OG_NTP_UPDATE_TIME		1				// ntp refresh state, initializes timeout handling
-#define OG_NTP_CALL_NTP			2				// actual ntp call, including success and basic retry states
-#define TIME_SYNC_CONFIG_DELAY	0				// delay between configuring the NTP class and actually using it, may not be needed anymore, so default to zero
-#define TIME_SYNC_RETRY_DELAY	2000			// delay between failed NTP calls, hopefully due to transient/startup issues
-#define TIME_SYNC_TIMEOUT		30000			// time limit before we give up calling NTP for a while, likely due to major issues, like a network outages
-#define TIME_SYNC_TIMEOUT_DELAY	60000			// delay before trying to call NTP again after a major issue
-#define TIME_SYNC_REFRESH 		1800000			// Issues connecting to MQTT can throw off the time function, sync more often
-#define TIME_SYNC_ERROR_DATE	1577836800UL	// 2020-01-01T00:00:00Z - Arbitrary, but reasonable date to confirm NTP is working
+#define OG_NTP_CONFIGURE		0            // ntp config state
+#define OG_NTP_UPDATE_TIME		1            // ntp refresh state, initializes timeout handling
+#define OG_NTP_CALL_NTP			2            // actual ntp call, including success and basic retry states
+#define TIME_SYNC_CONFIG_DELAY	0            // delay between configuring the NTP class and actually using it, may not be needed anymore, so default to zero
+#define TIME_SYNC_RETRY_DELAY	2000         // delay between failed NTP calls, hopefully due to transient/startup issues
+#define TIME_SYNC_TIMEOUT		30000        // time limit before we give up calling NTP for a while, likely due to major issues, like a network outages
+#define TIME_SYNC_TIMEOUT_DELAY	60000        // delay before trying to call NTP again after a major issue
+#define TIME_SYNC_REFRESH 		1800000      // Issues connecting to MQTT can throw off the time function, sync more often
+#define TIME_SYNC_ERROR_DATE	1577836800UL // 2020-01-01T00:00:00Z - Arbitrary, but reasonable date to confirm NTP is working
 
 #define TMP_BUFFER_SIZE 100
 

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -1252,52 +1252,85 @@ void check_status() {
 }
 
 void time_keeping() {
-	static bool configured = false;
+	static byte ntp_state = OG_NTP_CONFIGURE;
 	static ulong prev_millis = 0;
-	static ulong time_keeping_timeout = 0;
+	static ulong ntp_timeout = 0;
+	static ulong state_transition_time = 0;
 
-	if(!configured) {
-		if(valid_url(og.options[OPTION_NTP1].sval)) {
-			DEBUG_PRINT(F("NTP1:"));
-			DEBUG_PRINTLN(og.options[OPTION_NTP1].sval);
-			configTime(0, 0, og.options[OPTION_NTP1].sval.c_str(), DEFAULT_NTP1, DEFAULT_NTP2);
-		} else {
-			DEBUG_PRINT(F("NTP1:"));
-			DEBUG_PRINTLN(DEFAULT_NTP1);
-			configTime(0, 0, DEFAULT_NTP1, DEFAULT_NTP2, DEFAULT_NTP3);
-		}
-		configured = true;
-		delay(1000);
-	}
+	ulong current_millis = millis();
+	ulong state_transition_delay = 0;
 
-	if(!curr_utc_time || (curr_utc_time > time_keeping_timeout)) {
-		ulong gt = 0;
-		ulong timeout = millis()+30000;
-		do {
-			gt = time(nullptr);
-			delay(2000);
-		} while(gt<1577836800UL && millis()<timeout);
-		if(gt<1577836800UL) {
-			// if we didn't get response, re-try after 2 seconds
-			DEBUG_PRINTLN(F("ntp invalid! re-try in 60 seconds"));
-			time_keeping_timeout = curr_utc_time + 60;
-		} else {
-			curr_utc_time = gt;
-			curr_utc_hour = (curr_utc_time % 86400)/3600;
-			DEBUG_PRINT(F("Updated time from NTP: "));
-			DEBUG_PRINT(curr_utc_time);
-			DEBUG_PRINT(" Hour: ");
-			DEBUG_PRINTLN(curr_utc_hour);
-			// if we got a response, re-try after TIME_SYNC_TIMEOUT seconds
-			time_keeping_timeout = curr_utc_time + TIME_SYNC_TIMEOUT;
-			prev_millis = millis();
-		}
-	}
-
-	while(millis() - prev_millis >= 1000) {
+	while(current_millis - prev_millis >= 1000) {
 		curr_utc_time ++;
 		curr_utc_hour = (curr_utc_time % 86400)/3600;
 		prev_millis += 1000;
+	}
+
+	if(state_transition_time > current_millis){
+		return;
+	}
+
+	state_transition_time = 0;
+
+	switch(ntp_state) {
+		case OG_NTP_CONFIGURE: {
+			DEBUG_PRINT(F("NTP1: "));
+			if(valid_url(og.options[OPTION_NTP1].sval)) {
+				DEBUG_PRINTLN(og.options[OPTION_NTP1].sval);
+				configTime(0, 0, og.options[OPTION_NTP1].sval.c_str(), DEFAULT_NTP1, DEFAULT_NTP2);
+			} else {
+				DEBUG_PRINTLN(DEFAULT_NTP1);
+				configTime(0, 0, DEFAULT_NTP1, DEFAULT_NTP2, DEFAULT_NTP3);
+			}
+			DEBUG_PRINTLN(F("NTP Configured"));
+			ntp_state = OG_NTP_UPDATE_TIME;
+			state_transition_delay = TIME_SYNC_CONFIG_DELAY;
+			break;
+		}
+		case OG_NTP_UPDATE_TIME: {
+			DEBUG_PRINTLN(F("Updating Time"));
+			ntp_timeout = current_millis + TIME_SYNC_TIMEOUT;
+			ntp_state = OG_NTP_CALL_NTP;
+			break;
+		}
+		case OG_NTP_CALL_NTP: {
+			DEBUG_PRINTLN(F("Calling NTP Server"));
+			ulong gt = time(nullptr);
+			//ulong gt = TIME_SYNC_ERROR_DATE + current_millis;
+			if(gt < TIME_SYNC_ERROR_DATE){
+				DEBUG_PRINT(F("NTP Server Error: "));
+				// the result of ntp time failed, if we haven't reached the timeout window yet, wait 2 seconds, then try again, once we timeout, wait 60 seconds before trying again.
+				if(current_millis > ntp_timeout ){
+					DEBUG_PRINTLN(F("TIMEOUT"));
+					ntp_state = OG_NTP_UPDATE_TIME;
+					state_transition_delay = TIME_SYNC_TIMEOUT_DELAY;
+				} else {
+					DEBUG_PRINTLN(F("WAIT/RETRY"));
+					ntp_state = OG_NTP_CALL_NTP;
+					state_transition_delay = TIME_SYNC_RETRY_DELAY;
+				}
+			}
+			else{
+				curr_utc_time = gt;
+				curr_utc_hour = (curr_utc_time % 86400)/3600;
+				DEBUG_PRINT(F("Updated time from NTP: "));
+				DEBUG_PRINT(curr_utc_time);
+				DEBUG_PRINT(" Hour: ");
+				DEBUG_PRINTLN(curr_utc_hour);
+
+				prev_millis = current_millis;
+
+				// if we got a response, re-try after TIME_SYNC_REFRESH milliseconds
+				ntp_state = OG_NTP_UPDATE_TIME;
+				state_transition_delay = TIME_SYNC_REFRESH;
+			}
+			break;
+		}
+	}
+
+	if(state_transition_delay){
+		state_transition_time = current_millis + state_transition_delay;
+		state_transition_delay = 0;
 	}
 }
 


### PR DESCRIPTION
To get rid of the calls to delay() and use the loop itself, it seemed easiest to use a very simple state machine + a transition time (to replace the delay call) between states, where the transition time is defined by the loop millis() call.

Basically, the first state is the CONFIGURE state, which, once you exit, you can't go back to.  That always sends you to the UPDATE_TIME state, which sets up the timeout at 30 seconds, then sets the state to CALL_NTP, which actually calls the ntp server.  This state can succeed, in which case it updates all the time stuff, and updates the state to UPDATE_TIME with a transition time of 1800 seconds (per the previous implementation).  If it fails before the timeout (30 seconds, per the previous implementation), it moves the state back to CALL_NTP, with a 2 second transition time.  If it fails after the timeout, it moves the state to UPDATE_TIME with a transition time of 60 seconds (per the previous implementation), which resets the timeout to 30 seconds, and the process repeats.

One behavior I did change is that there was a 1 second delay between calling configTime and time(nullptr).  I noticed that in the old code, this was required or the first call to time(nullptr) would always fail.  After moving to the state transition model, this no longer happens.  I suspect some background work needs to happen between configTime and time(nullptr), which can occur now because we aren't blocking with delay and we are existing the loop.  I set the transition time to 0, but made it configurable in the defines.  My preference would be to delete the transition time delay completely since I don't think it's necessary anymore (and if it happens to fail occasionally on the first call, the retry should cover it), but I left it for now.

Another potential improvement would be to use a backoff strategy for the retry instead of a fixed 2 second retry (up to the 30 minute retry for MQTT) .  That might be simpler and more effective than the retry/timeout complexity now that there are no longer challenges with avoiding the delay(), but I wanted to submit a version that was functionally the same, so here it is.