### PR TITLE
[feature] Comma delimited email recipients

### DIFF
--- a/OpenGarage/html/sta_options.html
+++ b/OpenGarage/html/sta_options.html
@@ -85,7 +85,7 @@
 <tr class='email'><td><b>SMTP Port:</b></td><td><input type='text' size=5 maxlength=5 id='sprt' data-mini='true'></td></tr>
 <tr class='email'><td><b>Sender Email:</b></td><td><input type='text' size=16 maxlength=64 id='send' data-mini='true'></td></tr>
 <tr class='email'><td><b>App Password:</b></td><td><input type='text' size=16 maxlength=64 id='apwd' data-mini='true'></td></tr>
-<tr class='email'><td><b>Recipient Email:</b></td><td><input type='text' size=16 maxlength=64 id='recp' data-mini='true'></td></tr>
+<tr class='email'><td><b>Recipient Email(s):</b></td><td><input type='text' size=16 maxlength=64 id='recp' data-mini='true' placeholder='Comma separate entries(email1,email2)'></td></tr>
 <tr height=30px><td colspan=2><b>Choose Notification Events:</b></td></tr>
 <tr><td><input type='checkbox' id='noto0' data-mini='true'><label for='noto0'>Door Open</label></td><td><input type='checkbox' id='noto1' data-mini='true' ><label for='noto1'>Door Close</label></td></tr>
 <tr><td><b>IFTTT Key:</b></td><td><input type='text' size=20 maxlength=64 id='iftt' data-mini='true' placeholder='(if using IFTTT notification)'></td></tr>

--- a/OpenGarage/main.cpp
+++ b/OpenGarage/main.cpp
@@ -31,6 +31,9 @@
 #include <OpenThingsFramework.h>
 #include <Request.h>
 #include <Response.h>
+#include <sstream>
+#include <vector>
+#include <string>
 
 #include "pitches.h"
 #include "OpenGarage.h"
@@ -1029,7 +1032,33 @@ void emailNotify(String s){
 		emailSend.setSMTPServer(email_host);
 		emailSend.setSMTPPort(email_port);
 		DEBUG_PRINTLN(GET_FREE_HEAP);
-		EMailSender::Response resp = emailSend.send(email_recip, email_message);
+
+		// Check for multiple recipients (comma-delimited)
+		std::string recipients(email_recip);
+    if (recipients.find(",") != std::string::npos) {
+      // Split the recipients string
+      std::vector<std::string> tokens;
+      std::stringstream ss(recipients);
+      std::string token;
+      while (std::getline(ss, token, ',')) {
+        tokens.push_back(token);
+      }
+      std::vector<std::string> recipientList = tokens;
+
+      // Convert to an array of const char*
+      const char* to[recipientList.size()];
+      for (size_t i = 0; i < recipientList.size(); ++i) {
+        to[i] = recipientList[i].c_str();
+      }
+      byte sizeOfTo = static_cast<byte>(recipientList.size());
+
+      // Call the send method for multiple recipients
+      EMailSender::Response resp = emailSend.send(to, sizeOfTo, email_message);
+    } else {
+      // Call the send method for a single recipient
+      EMailSender::Response resp = emailSend.send(email_recip, email_message);
+    }
+
 	}
 }
 


### PR DESCRIPTION
Feature:
- Add support for multiple comma delimited email recipients. Default to existing email send if single recipient found.
- Update html

Output of PlatformIO:Build
```
Processing d1_mini (platform: espressif8266@4.2.1; board: d1_mini; framework: arduino)
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/espressif8266/d1_mini.html
PLATFORM: Espressif 8266 (4.2.1) > WeMos D1 R2 and mini
HARDWARE: ESP8266 80MHz, 80KB RAM, 4MB Flash
PACKAGES: 
 - framework-arduinoespressif8266 @ 3.30102.0 (3.1.2) 
 - tool-esptool @ 1.413.0 (4.13) 
 - tool-esptoolpy @ 1.30000.201119 (3.0.0) 
 - toolchain-xtensa @ 2.100300.220621 (10.3.0)
Converting ogMainArduino.ino
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ deep, Compatibility ~ soft
Found 46 compatible libraries
Scanning dependencies...
Dependency Graph
|-- PubSubClient @ 2.8.0
|-- Blynk @ 1.0.1
|-- AM2320 @ 0.0.0+20250319100543
|-- OneWire @ 2.3.7
|-- DallasTemperature @ 3.9.1
|-- DHT sensor library for ESPx @ 1.18.0
|-- OpenThings-Framework-Firmware-Library @ 0.2.0+sha.0f74fa7
|-- DNSServer @ 1.1.1
|-- ESP8266WebServer @ 1.0
|-- ESP8266WiFi @ 1.0
|-- ESP8266mDNS @ 1.2
|-- LittleFS @ 0.1.0
|-- ESP8266SdFat @ 2.1.1
|-- Ethernet @ 2.0.0
|-- SD @ 2.0.0
|-- SPI @ 1.0
|-- Ticker @ 1.0
|-- ESP8266HTTPClient @ 1.2
|-- WebSockets @ 2.6.1
Building in release mode
Compiling .pio/build/d1_mini/src/ogMainArduino.ino.cpp.o
Retrieving maximum program size .pio/build/d1_mini/firmware.elf
Checking size .pio/build/d1_mini/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [======    ]  56.3% (used 46148 bytes from 81920 bytes)
Flash: [=======   ]  70.8% (used 739901 bytes from 1044464 bytes)
================================================================================ [SUCCESS] Took 3.98 seconds ================================================================================
``` 